### PR TITLE
Fixed bug on Error tracing

### DIFF
--- a/src/System.Diagnostics.Tracer.Desktop/DiagnosticsTracer.cs
+++ b/src/System.Diagnostics.Tracer.Desktop/DiagnosticsTracer.cs
@@ -6,141 +6,144 @@ using System.Xml.XPath;
 
 namespace System.Diagnostics
 {
-	/// <summary>
-	/// Implements the <see cref="ITracer"/> interface on top of
-	/// <see cref="TraceSource"/>.
-	/// </summary>
-	class DiagnosticsTracer
-	{
-		TraceSource source;
+    /// <summary>
+    /// Implements the <see cref="ITracer"/> interface on top of
+    /// <see cref="TraceSource"/>.
+    /// </summary>
+    class DiagnosticsTracer
+    {
+        TraceSource source;
 
-		public DiagnosticsTracer(TraceSource source)
-		{
-			this.source = source;
-		}
+        public DiagnosticsTracer(TraceSource source)
+        {
+            this.source = source;
+        }
 
-		public void Trace(string sourceName, TraceEventType type, object message)
-		{
-			lock (source)
-			{
-				using (new SourceNameReplacer(source, sourceName))
-				{
-					// Transfers with a Guid payload should instead trace a transfer
-					// with that as the related Guid.
-					var guid = message as Guid?;
-					if (guid != null && type == TraceEventType.Transfer)
-						source.TraceTransfer(0, "Transfer", guid.Value);
-					else
-						source.TraceEvent(type, 0, message.ToString());
-				}
-			}
-		}
+        public void Trace(string sourceName, TraceEventType type, object message)
+        {
+            lock (source)
+            {
+                using (new SourceNameReplacer(source, sourceName))
+                {
+                    // Transfers with a Guid payload should instead trace a transfer
+                    // with that as the related Guid.
+                    var guid = message as Guid?;
+                    if (guid != null && type == TraceEventType.Transfer)
+                        source.TraceTransfer(0, "Transfer", guid.Value);
+                    else
+                        source.TraceEvent(type, 0, message.ToString());
+                }
+            }
+        }
 
-		public void Trace(string sourceName, TraceEventType type, string format, params object[] args)
-		{
-			lock (source)
-			{
-				using (new SourceNameReplacer(source, sourceName))
-				{
-					source.TraceEvent(type, 0, format, args);
-				}
-			}
-		}
+        public void Trace(string sourceName, TraceEventType type, string format, params object[] args)
+        {
+            lock (source)
+            {
+                using (new SourceNameReplacer(source, sourceName))
+                {
+                    source.TraceEvent(type, 0, format, args);
+                }
+            }
+        }
 
-		public void Trace(string sourceName, TraceEventType type, Exception exception, object message)
-		{
-			Trace(sourceName, type, exception, message.ToString());
-		}
+        public void Trace(string sourceName, TraceEventType type, Exception exception, object message)
+        {
+            Trace(sourceName, type, exception, message.ToString());
+        }
 
-		public void Trace(string sourceName, TraceEventType type, Exception exception, string format, params object[] args)
-		{
-			lock (source)
-			{
-				using (new SourceNameReplacer(source, sourceName))
-				{
-					var message = format;
-					if (args != null && args.Length > 0)
-						message = string.Format(CultureInfo.CurrentCulture, format, args);
+        public void Trace(string sourceName, TraceEventType type, Exception exception, string format, params object[] args)
+        {
+            lock (source)
+            {
+                using (new SourceNameReplacer(source, sourceName))
+                {
+                    var message = format;
+                    if (args != null && args.Length > 0)
+                        message = string.Format(CultureInfo.CurrentCulture, format, args);
 
-					if (TraceExceptionXml(exception, message))
-					{
-						// This means we've traced the exception as XML to at least one XML writer,
-						// So we should skip the next event from them.
-						var xmlListeners = source.Listeners.OfType<XmlWriterTraceListener>().ToArray();
-						foreach (var listener in xmlListeners)
-						{
-							source.Listeners.Remove(listener);
-						}
+                    var hasXmlListeners = source.Listeners.OfType<XmlWriterTraceListener>().Any();
+                    var xmlListeners = default(XmlWriterTraceListener[]);
 
-						try
-						{
-							source.TraceEvent(type, 0, string.Format(format, args) + Environment.NewLine + exception);
-						}
-						finally
-						{
-							source.Listeners.AddRange(xmlListeners);
-						}
-					}
-				}
-			}
-		}
+                    try
+                    {
+                        if (hasXmlListeners)
+                        {
+                            TraceExceptionXml(exception, message);
 
-		const string TraceXmlNs = "http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord";
+                            // This means we've traced the exception as XML to at least one XML writer,
+                            // So we should skip the next event from them.
+                            xmlListeners = source.Listeners.OfType<XmlWriterTraceListener>().ToArray();
 
-		bool TraceExceptionXml(Exception exception, string format, params object[] args)
-		{
-			if (source.Listeners.OfType<XmlWriterTraceListener>().Any())
-			{
-				var message = format;
-				if (args != null && args.Length > 0)
-					message = string.Format(CultureInfo.CurrentCulture, format, args);
+                            foreach (var listener in xmlListeners)
+                            {
+                                source.Listeners.Remove(listener);
+                            }
+                        }
 
-				var xdoc = new XDocument();
-				var writer = xdoc.CreateWriter();
+                        source.TraceEvent(type, 0, string.Format(format, args) + Environment.NewLine + exception);
+                    }
+                    finally
+                    {
+                        if (hasXmlListeners)
+                        {
+                            source.Listeners.AddRange(xmlListeners);
+                        }
+                    }
+                }
+            }
+        }
 
-				writer.WriteStartElement("", "TraceRecord", TraceXmlNs);
-				writer.WriteAttributeString("Severity", "Error");
-				//writer.WriteElementString ("TraceIdentifier", msdnTraceCode);
-				writer.WriteElementString("Description", TraceXmlNs, message);
-				writer.WriteElementString("AppDomain", TraceXmlNs, AppDomain.CurrentDomain.FriendlyName);
-				writer.WriteElementString("Source", TraceXmlNs, source.Name);
-				AddExceptionXml(writer, exception);
-				writer.WriteEndElement();
+        const string TraceXmlNs = "http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord";
 
-				writer.Flush();
-				writer.Close();
+        void TraceExceptionXml(Exception exception, string format, params object[] args)
+        {
+            var message = format;
+            if (args != null && args.Length > 0)
+                message = string.Format(CultureInfo.CurrentCulture, format, args);
 
-				source.TraceData(TraceEventType.Error, 0, xdoc.CreateNavigator());
-				return true;
-			}
+            var xdoc = new XDocument();
+            var writer = xdoc.CreateWriter();
 
-			return false;
-		}
+            writer.WriteStartElement("", "TraceRecord", TraceXmlNs);
+            writer.WriteAttributeString("Severity", "Error");
+            //writer.WriteElementString ("TraceIdentifier", msdnTraceCode);
+            writer.WriteElementString("Description", TraceXmlNs, message);
+            writer.WriteElementString("AppDomain", TraceXmlNs, AppDomain.CurrentDomain.FriendlyName);
+            writer.WriteElementString("Source", TraceXmlNs, source.Name);
+            AddExceptionXml(writer, exception);
+            writer.WriteEndElement();
 
-		static void AddExceptionXml(XmlWriter xml, Exception exception)
-		{
-			xml.WriteElementString("ExceptionType", TraceXmlNs, exception.GetType().AssemblyQualifiedName);
-			xml.WriteElementString("Message", TraceXmlNs, exception.Message);
-			xml.WriteElementString("StackTrace", TraceXmlNs, exception.StackTrace);
-			xml.WriteElementString("ExceptionString", TraceXmlNs, exception.ToString());
+            writer.Flush();
+            writer.Close();
 
-			if ((exception.Data != null) && (exception.Data.Count > 0))
-			{
-				xml.WriteStartElement("DataItems", TraceXmlNs);
-				foreach (var key in exception.Data.Keys)
-				{
-					var data = exception.Data[key];
-					xml.WriteElementString(key.ToString(), data != null ? data.ToString() : "");
-				}
-				xml.WriteEndElement();
-			}
+            source.TraceData(TraceEventType.Error, 0, xdoc.CreateNavigator());
+        }
 
-			if (exception.InnerException != null)
-			{
-				xml.WriteStartElement("InnerException", TraceXmlNs);
-				AddExceptionXml(xml, exception.InnerException);
-				xml.WriteEndElement();
-			}
-		}
-	}
+        static void AddExceptionXml(XmlWriter xml, Exception exception)
+        {
+            xml.WriteElementString("ExceptionType", TraceXmlNs, exception.GetType().AssemblyQualifiedName);
+            xml.WriteElementString("Message", TraceXmlNs, exception.Message);
+            xml.WriteElementString("StackTrace", TraceXmlNs, exception.StackTrace);
+            xml.WriteElementString("ExceptionString", TraceXmlNs, exception.ToString());
+
+            if ((exception.Data != null) && (exception.Data.Count > 0))
+            {
+                xml.WriteStartElement("DataItems", TraceXmlNs);
+                foreach (var key in exception.Data.Keys)
+                {
+                    var data = exception.Data[key];
+                    xml.WriteElementString(key.ToString(), data != null ? data.ToString() : "");
+                }
+                xml.WriteEndElement();
+            }
+
+            if (exception.InnerException != null)
+            {
+                xml.WriteStartElement("InnerException", TraceXmlNs);
+                AddExceptionXml(xml, exception.InnerException);
+                xml.WriteEndElement();
+            }
+        }
+    }
 }

--- a/src/System.Diagnostics.Tracer.Tests/TracerTests.cs
+++ b/src/System.Diagnostics.Tracer.Tests/TracerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,25 +8,86 @@ using Xunit;
 
 namespace System.Diagnostics
 {
-	public class TracerTests
-	{
-		[Fact]
-		public void when_getting_source_name_from_type_then_retrieves_full_name ()
-		{
-			var name = Tracer.NameFor<TracerTests>();
+    public class TracerTests
+    {
+        [Fact]
+        public void when_getting_source_name_from_type_then_retrieves_full_name()
+        {
+            var name = Tracer.NameFor<TracerTests>();
 
-			Assert.Equal (typeof (TracerTests).FullName, name);
-		}
+            Assert.Equal(typeof(TracerTests).FullName, name);
+        }
 
-		/// <summary>
-		/// <see cref="System.Lazy{System.Tuple{String, int}}"/>.
-		/// </summary>
-		[Fact]
-		public void when_getting_source_name_for_generics_type_then_retrieves_documentation_style_generic ()
-		{
-			var name = Tracer.NameFor<Lazy<Tuple<string, int>>>();
+        /// <summary>
+        /// <see cref="System.Lazy{System.Tuple{String, int}}"/>.
+        /// </summary>
+        [Fact]
+        public void when_getting_source_name_for_generics_type_then_retrieves_documentation_style_generic()
+        {
+            var name = Tracer.NameFor<Lazy<Tuple<string, int>>>();
 
-			Assert.Equal ("System.Lazy{System.Tuple{System.String,System.Int32}}", name);
-		}
-	}
+            Assert.Equal("System.Lazy{System.Tuple{System.String,System.Int32}}", name);
+        }
+
+        [Fact]
+        public void when_tracing_exception_with_xml_then_succeeds()
+        {
+            var xml = Path.GetTempFileName();
+            var inMemoryListener = new InMemoryTraceListener();
+            var xmlListener = new XmlWriterTraceListener(xml);
+
+            Tracer.Configuration.AddListener("Foo", inMemoryListener);
+            Tracer.Configuration.AddListener("Foo", xmlListener);
+            Tracer.Configuration.SetTracingLevel("Foo", SourceLevels.All);
+
+            var tracer = Tracer.Get("Foo");
+
+            tracer.Error(new ApplicationException("Foo Error"), "A Foo Exception occurred");
+
+            var trace = inMemoryListener.GetTrace();
+
+            Assert.False(string.IsNullOrEmpty(trace));
+            Assert.Contains("Foo Error", trace);
+            Assert.Contains("A Foo Exception occurred", trace);
+        }
+
+        [Fact]
+        public void when_tracing_exception_without_xml_then_succeeds()
+        {
+            var inMemoryListener = new InMemoryTraceListener();
+
+            Tracer.Configuration.AddListener("Foo", inMemoryListener);
+            Tracer.Configuration.SetTracingLevel("Foo", SourceLevels.All);
+
+            var tracer = Tracer.Get("Foo");
+
+            tracer.Error(new ApplicationException("Foo Error"), "A Foo Exception occurred");
+
+            var trace = inMemoryListener.GetTrace();
+
+            Assert.False(string.IsNullOrEmpty(trace));
+            Assert.Contains("Foo Error", trace);
+            Assert.Contains("A Foo Exception occurred", trace);
+        }
+    }
+
+    class InMemoryTraceListener : TraceListener
+    {
+        readonly StringBuilder traceBuilder = new StringBuilder();
+
+        public override void Write(string message)
+        {
+            traceBuilder.Append(message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            traceBuilder.AppendLine(message);
+        }
+
+        public string GetTrace()
+        {
+            return traceBuilder.ToString();
+        }
+    }
 }


### PR DESCRIPTION
- When the DiagnosticsTracer had to trace an Error with an Exception, it was always assuming that an XmlWriterTraceListener was present. So, in the cases where an XmlWriterTraceListener hasn't been added, then no exception tracing were performed.
- This fix makes the existence of an XmlWriterTraceListener as non required to trace an exception in the specific EventSource.