### PR TITLE
Added "AppendElapsedTime" option to the start activity

### DIFF
--- a/src/System.Diagnostics.Tracer.Tests/StartActivityTests.cs
+++ b/src/System.Diagnostics.Tracer.Tests/StartActivityTests.cs
@@ -162,5 +162,24 @@ namespace System.Diagnostics
 			//Process.Start (@"C:\Program Files (x86)\Microsoft SDKs\Windows\v8.0A\bin\NETFX 4.0 Tools\SvcTraceViewer.exe", xml);
 			//Process.Start (@"C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\SvcTraceViewer.exe", xml);
 		}
+
+		[Fact]
+		public void when_using_activity_with_elapsed_time_then_stop_message_includes_elapsed_time()
+		{
+			var listener = new Mock<TraceListener>();
+			Tracer.Configuration.AddListener("Foo", listener.Object);
+			Tracer.Configuration.SetTracingLevel("Foo", SourceLevels.All);
+
+			var tracer = Tracer.Get("Foo");
+
+			using (var activity = tracer.StartActivity("Test", appendElapsedTime: true)) ;
+
+			listener.Verify(x => x.TraceEvent(
+			   It.IsAny<TraceEventCache>(),
+			   "Foo",
+			   TraceEventType.Stop,
+			   It.IsAny<int>(),
+			   It.Is<string>(message => message.StartsWith("Test") && message.EndsWith(" ms)"))));
+		}
 	}
 }

--- a/src/System.Diagnostics.Tracer/StartActivityExtension.cs
+++ b/src/System.Diagnostics.Tracer/StartActivityExtension.cs
@@ -30,6 +30,14 @@ namespace System.Diagnostics
 			return disposable;
 		}
 
+		/// <summary>
+		/// Starts a new activity scope.
+		/// </summary>
+		public static IDisposable StartActivity(this ITracer tracer, string displayName, bool appendElapsedTime)
+		{
+			return disposable;
+		}
+
 		class NullDisposable : IDisposable
 		{
 			public void Dispose()


### PR DESCRIPTION
In order to log how much time the execution of the activity took.

For example: using(tracer.StartActivity ("Loading settings...", appendElapsedTime: true) { ... }

Will generate the following messages:

Start: Loading settings...
...
Stop: Loading settings... (123 ms)